### PR TITLE
WIP: Allow for overriding the platform to build for

### DIFF
--- a/nightly/install_clean.sh
+++ b/nightly/install_clean.sh
@@ -11,6 +11,10 @@ if [ "$DATE" != "" ]; then
 	export CLEANDATE="$DATE"
 fi
 
+if [ "$PLATFORM" == "" ]; then
+	export PLATFORM="linux-x64"
+fi
+
 PACKAGES="gcc make subversion git ca-certificates curl rsync"
 apt-get update -qq
 apt-get install -qq $PACKAGES --no-install-recommends
@@ -18,7 +22,7 @@ rm -rf /var/lib/apt/lists/*
 
 cd /tmp
 git clone https://gitlab.science.ru.nl/clean-and-itasks/clean-build
-cd "clean-build/clean-$TARGET/linux-x64"
+cd "clean-build/clean-$TARGET/$PLATFORM"
 
 ./fetch.sh
 ./setup.sh


### PR DESCRIPTION
I would prefer a script which accepts options (`--dist clean-bundle-complete`, `--platform linux-x64`, `--date 2018-03-15`). This is a breaking change and needs to be tested thoroughly.